### PR TITLE
Fix bug, wrong use in systemd file

### DIFF
--- a/common/usr/lib/MailScanner/systemd/ms-systemd
+++ b/common/usr/lib/MailScanner/systemd/ms-systemd
@@ -16,7 +16,6 @@ RemainAfterExit=yes
 ExecStart=/usr/lib/MailScanner/init/ms-init start
 ExecStop=/usr/lib/MailScanner/init/ms-init stop
 EnvironmentFile=-/etc/MailScanner/defaults
-ExecReload=no
 PIDFile=/var/run/MailScanner.pid
 
 [Install]


### PR DESCRIPTION
syslog reports :  [/lib/systemd/system/mailscanner.service:19] Executable path is not absolute, ignoring: no
Removed the reload line from mailscanner.service file.